### PR TITLE
Add Academy to Link Box

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![FIWARE Security](https://nexus.lab.fiware.org/static/badges/chapters/processing.svg)](https://www.fiware.org/developers/catalogue/)
 [![License: BSD-4-Clause](https://img.shields.io/badge/license-BSD%204%20Clause-blue.svg)](https://spdx.org/licenses/BSD-4-Clause.html)
 [![Docker Status](https://img.shields.io/docker/pulls/fogflow/discovery.svg)](https://hub.docker.com/r/fogflow)
-[![Support badge](https://img.shields.io/badge/tag-fiware-orange.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/fiware)
+[![Support badge](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/fogflow.svg)](https://stackoverflow.com/search?q=%5Bfiware%5D%20fogflow)
 <br>
 [![Documentation badge](https://img.shields.io/readthedocs/fogflow.svg)](http://fogflow.readthedocs.org/en/latest/)
 ![Status](https://nexus.lab.fiware.org/repository/raw/public/static/badges/statuses/fogflow.svg)
@@ -21,8 +21,8 @@ check the FIWARE Catalogue entry for
 [Processing](https://github.com/Fiware/catalogue/tree/master/processing).
 
 
-| :books: [Documentation](https://fogflow.rtfd.io/) | :whale: [Docker Hub](https://hub.docker.com/r/fogflow) | :dart: [Roadmap](https://github.com/smartfog/fogflow/blob/master/roadmap.md) |
-| --- | --- | --- | 
+| :books: [Documentation](https://fogflow.rtfd.io/) | :mortar_board: [Academy](https://fiware-academy.readthedocs.io/en/latest/processing/fogflow) |:whale: [Docker Hub](https://hub.docker.com/r/fogflow) | :dart: [Roadmap](https://github.com/smartfog/fogflow/blob/master/roadmap.md) |
+| --- | --- | --- | --- |
 
 ## Content
 


### PR DESCRIPTION
@showersky  - Related to #14 - I have added the Slidedeck and sample code **training materials**  to the [FIWARE Academy](https://fiware-academy.readthedocs.io/en/latest/processing/fogflow). This PR adds an entry to the link box on the Main `README` to direct users to the **training materials** in a standard manner.

The file:  https://github.com/smartfog/fogflow/blob/master/doc/training/fogflow.md is probably unnecessary now.

This would complete fulfillment of the weaker "MUST have (some) training materials" criterion. The integrated tutorial requirement would still need to be done in the next 6 months or so.