### PR TITLE
Add submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "grafana/prometheus/src/github.com/ant0ine/go-json-rest"]
+	path = grafana/prometheus/src/github.com/ant0ine/go-json-rest
+	url = https://github.com/ant0ine/go-json-rest


### PR DESCRIPTION
When I checkout fogflow and run:

```console
git submodule status
```

I get the following error:

```
fatal: no submodule mapping found in .gitmodules for path 'grafana/prometheus/src/github.com/ant0ine/go-json-rest'
```
This means I am unable to refresh the repository with:

```console
git submodule update --init --recursive
```

The issue is displayed graphically here: https://github.com/smartfog/fogflow/tree/development/grafana/prometheus/src/github.com/ant0ine

The submodule cannot be accessed.


This PR fixes the issue by adding the missing `.gitmodules` file to the repo.
