### PR TITLE
change the configuration file to use clusterIP for the k8s deployment

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -52,15 +52,18 @@ type Config struct {
 		Debug    string `json:"debug"`
 	} `json:"logging"`
 	Discovery struct {
-		HTTPPort  int `json:"http_port"`
-		HTTPSPort int `json:"https_port"`
+		HostIP    string `json:"host_ip"`
+		HTTPPort  int    `json:"http_port"`
+		HTTPSPort int    `json:"https_port"`
 	} `json:"discovery"`
 	Broker struct {
-		HTTPPort  int `json:"http_port"`
-		HTTPSPort int `json:"https_port"`
+		HostIP    string `json:"host_ip"`
+		HTTPPort  int    `json:"http_port"`
+		HTTPSPort int    `json:"https_port"`
 	} `json:"broker"`
 	Master struct {
-		AgentPort int `json:"ngsi_agent_port"`
+		HostIP    string `json:"host_ip"`
+		AgentPort int    `json:"ngsi_agent_port"`
 	} `json:"master"`
 	Worker struct {
 		Registry            RegistryConfiguration `json:"registry,omitempty"`
@@ -71,6 +74,7 @@ type Config struct {
 		CAdvisorPort int `json:"cadvisor_port"`
 	} `json:"worker"`
 	RabbitMQ struct {
+		HostIP   string `json:"host_ip"`
 		Port     int    `json:"port"`
 		Username string `json:"username"`
 		Password string `json:"password"`
@@ -96,11 +100,21 @@ func (c *Config) GetDiscoveryURL() string {
 		hostip = c.CoreSerivceIP
 	}
 
+	if c.Discovery.HostIP != "" {
+		hostip = c.Discovery.HostIP
+	}
+
 	return fmt.Sprintf("%s://%s:%d/ngsi9", protocol, hostip, port)
 }
 
 func (c *Config) GetBrokerURL4Task() string {
-	return "http://" + c.InternalIP + ":" + strconv.Itoa(c.Broker.HTTPPort) + "/ngsi10"
+	brokeIP := c.InternalIP
+
+	if c.Broker.HostIP != "" {
+		brokeIP = c.Broker.HostIP
+	}
+
+	return "http://" + brokeIP + ":" + strconv.Itoa(c.Broker.HTTPPort) + "/ngsi10"
 }
 
 func (c *Config) GetBrokerURL() string {
@@ -116,17 +130,34 @@ func (c *Config) GetBrokerURL() string {
 		hostip = c.ExternalIP
 	}
 
+	if c.Broker.HostIP != "" {
+		hostip = c.Broker.HostIP
+	}
+
 	return fmt.Sprintf("%s://%s:%d/ngsi10", protocol, hostip, port)
 }
 
-func (c *Config) GetMyAccessibleIP() string {
-	return c.InternalIP
+func (c *Config) GetMasterIP() string {
+	hostip := c.InternalIP
+	if c.ExternalIP != "" {
+		hostip = c.ExternalIP
+	}
+
+	if c.Master.HostIP != "" {
+		hostip = c.Master.HostIP
+	}
+
+	return hostip
 }
 
 func (c *Config) GetMessageBus() string {
 	hostip := c.InternalIP
 	if c.CoreSerivceIP != "" {
 		hostip = c.CoreSerivceIP
+	}
+
+	if c.RabbitMQ.HostIP != "" {
+		hostip = c.RabbitMQ.HostIP
 	}
 
 	messageBus := fmt.Sprintf("amqp://%s:%s@%s:%d/", c.RabbitMQ.Username, c.RabbitMQ.Password, hostip, c.RabbitMQ.Port)

--- a/deployment/kubernetes/cloud-node/broker.yaml
+++ b/deployment/kubernetes/cloud-node/broker.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: fogflow                      
+  name: cloudbroker
+spec:
+  selector:
+    matchLabels:
+      run: cloudbroker
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: cloudbroker
+    spec:
+      containers:
+      - name: cloudbroker
+        image: fogflow/broker:k8s
+        ports:
+        - containerPort: 8070  
+        volumeMounts:
+        - name: config-json       
+          mountPath: /config.json
+          subPath: config.json          
+          readOnly: true
+      volumes:
+      - name: config-json 
+        configMap:
+          name: fogflow-configmap       
+          
+---          
+          
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: fogflow                      
+  name: cloudbroker
+  labels:
+    run: cloudbroker
+spec:
+  ports:
+  - port: 8070
+    protocol: TCP
+  selector:
+    run: cloudbroker
+
+

--- a/deployment/kubernetes/cloud-node/configmap.yaml
+++ b/deployment/kubernetes/cloud-node/configmap.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+data:
+  config.json: |
+        {
+            "physical_location":{
+                "longitude": 139.709059,
+                "latitude": 35.692221
+            },
+            "site_id": "001",
+            "logging":{
+                "info":"stdout",
+                "error":"stdout",
+                "protocol": "stdout",
+                "debug": "stdout"
+            },
+            "discovery": {
+                "host_ip":"discovery",
+                "http_port": 8090
+            },
+            "broker": {
+                "host_ip":"cloudbroker",              
+                "http_port": 8070
+            },     
+            "master": {
+                "host_ip":"master",                            
+                "ngsi_agent_port": 1060    
+            },
+            "worker": {
+                "container_autoremove": false,
+                "start_actual_task": true,
+                "capacity": 8
+            },
+            "designer": {
+                "host_ip":"designer",                            
+                "webSrvPort": 8080,
+                "agentPort": 1030               
+            },    
+            "rabbitmq": {
+                "host_ip":"rabbitmq",                                          
+                "port": 5672,
+                "username": "admin",
+                "password":"mypass"
+            },
+            "https": {
+                "enabled" : false
+            },
+            "persistent_storage": {
+                "host_ip":"dgraph",                                                        
+                "port": 9080
+            } 
+        }
+
+  nginx.conf: |
+        events {
+          worker_connections  4096;  
+        }
+        
+        http {
+            server { 
+                listen              80;
+                server_name         www.fogflow.io;
+        
+                location / {
+                    proxy_pass   http://designer:8080/;
+                }
+        
+                location /ngsi9/ {
+                    proxy_pass   http://discovery:8090/ngsi9/;
+                }
+        
+                location /ngsi10/ {
+                    proxy_pass   http://cloudbroker:8070/ngsi10/;
+                }
+            
+                location /ngsi-ld/ {
+                    proxy_pass   http://cloudbroker:8070/ngsi-ld/;
+                }
+            }
+        }
+
+kind: ConfigMap
+metadata:
+  namespace: fogflow
+  name: fogflow-configmap
+  resourceVersion: "v3.2.2"

--- a/deployment/kubernetes/cloud-node/designer.yaml
+++ b/deployment/kubernetes/cloud-node/designer.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: fogflow                      
+  name: designer
+spec:
+  selector:
+    matchLabels:
+      run: designer
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: designer
+    spec:
+      containers:
+      - name: designer
+        image: fogflow/designer:k8s
+        ports:
+        - containerPort: 8080  
+        volumeMounts:
+        - name: config-json       
+          mountPath: /app/config.json
+          subPath: config.json                    
+          readOnly: true
+      volumes:
+      - name: config-json 
+        configMap:
+          name: fogflow-configmap               
+          
+---          
+          
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: fogflow                      
+  name: designer
+  labels:
+    run: designer
+spec:
+  type: LoadBalancer
+  ports:
+    - name: "8080"
+      port: 8080  
+      targetPort: 8080
+    - name: "1030"
+      port: 1030
+      targetPort: 1030     
+  selector:
+    run: designer
+
+
+

--- a/deployment/kubernetes/cloud-node/dgraph.yaml
+++ b/deployment/kubernetes/cloud-node/dgraph.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: fogflow                      
+  name: dgraph
+spec:
+  selector:
+    matchLabels:
+      run: dgraph
+  replicas: 1      
+  template:
+    metadata:
+      labels:
+        run: dgraph
+    spec:
+      containers:
+      - name: dgraph
+        image: dgraph/standalone
+        ports:
+        - containerPort: 6080
+        - containerPort: 8080
+        - containerPort: 9080
+        - containerPort: 8000
+        volumeMounts:
+        - name: dgraph 
+          mountPath: /dgraph 
+      volumes:
+      - name: dgraph
+        hostPath: 
+          path: /Users/cheng/work/github/fogflow/yaml/cloud-node/dgraph        
+          
+---          
+          
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: fogflow                      
+  name: dgraph
+  labels:
+    run: dgraph
+spec:
+  type: LoadBalancer
+  ports:  
+    - name: "6080"
+      port: 6080
+      targetPort: 6080
+    - name: "8080"
+      port: 8082
+      targetPort: 8080
+    - name: "9080"
+      port: 9080
+      targetPort: 9080
+    - name: "8000"
+      port: 8000
+      targetPort: 8000
+  selector:
+    run: dgraph
+
+
+

--- a/deployment/kubernetes/cloud-node/discovery.yaml
+++ b/deployment/kubernetes/cloud-node/discovery.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: fogflow                      
+  name: discovery
+spec:
+  selector:
+    matchLabels:
+      run: discovery
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: discovery
+    spec:
+      containers:
+      - name: discovery
+        image: fogflow/discovery:k8s
+        ports:
+        - containerPort: 8090  
+        volumeMounts:
+        - name: config-json       
+          mountPath: /config.json
+          subPath: config.json
+          readOnly: true
+      volumes:
+      - name: config-json 
+        configMap:
+          name: fogflow-configmap
+
+---          
+          
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: fogflow                      
+  name: discovery
+  labels:
+    run: discovery
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 8090
+      targetPort: 8090
+  selector:
+    run: discovery
+
+
+

--- a/deployment/kubernetes/cloud-node/install.sh
+++ b/deployment/kubernetes/cloud-node/install.sh
@@ -1,0 +1,18 @@
+mkdir -p dgraph
+
+kubectl  create namespace fogflow
+
+kubectl create -f configmap.yaml
+
+kubectl create -f discovery.yaml
+kubectl create -f broker.yaml
+kubectl create -f dgraph.yaml
+kubectl create -f rabbitmq.yaml
+kubectl create -f master.yaml
+kubectl create -f worker.yaml
+kubectl create -f designer.yaml
+
+kubectl create -f nginx.yaml
+
+
+

--- a/deployment/kubernetes/cloud-node/master.yaml
+++ b/deployment/kubernetes/cloud-node/master.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: fogflow                      
+  name: master
+spec:
+  selector:
+    matchLabels:
+      run: master
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: master
+    spec:
+      containers:
+      - name: master
+        image: fogflow/master:k8s
+        ports:
+        - containerPort: 1060
+        #readiness and liveness to check pod's Health
+        readinessProbe:
+          tcpSocket:
+            port: 1060
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 1060
+          initialDelaySeconds: 15
+          periodSeconds: 20          
+        volumeMounts:
+        - name: config-json       
+          mountPath: /config.json
+          subPath: config.json            
+          readOnly: true
+      volumes:
+      - name: config-json 
+        configMap:
+          name: fogflow-configmap    
+          
+---          
+          
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: fogflow                      
+  name: master
+  labels:
+    run: master
+spec:
+  ports:
+  - name: "1060"
+    port: 1060
+    targetPort: 1060
+  selector:
+    run: master
+

--- a/deployment/kubernetes/cloud-node/nginx.yaml
+++ b/deployment/kubernetes/cloud-node/nginx.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: fogflow                      
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      run: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80  
+        volumeMounts:
+        - name: nginx-conf      
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+          readOnly: true
+      volumes:
+      - name: nginx-conf
+        configMap:
+          name: fogflow-configmap                   
+          
+---          
+          
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: fogflow                      
+  name: nginx
+  labels:
+    run: nginx
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    run: nginx
+
+
+

--- a/deployment/kubernetes/cloud-node/rabbitmq.yaml
+++ b/deployment/kubernetes/cloud-node/rabbitmq.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: fogflow                      
+  name: rabbitmq
+spec:
+  selector:
+    matchLabels:
+      run: rabbitmq
+  replicas: 1      
+  template:
+    metadata:
+      labels:
+        run: rabbitmq
+    spec:
+      containers:    
+      - name: rabbitmq
+        image: rabbitmq:3
+        ports:
+        - containerPort: 5672
+        env:
+        - name: RABBITMQ_DEFAULT_PASS
+          value: mypass
+        - name: RABBITMQ_DEFAULT_USER
+          value: admin          
+             
+---          
+          
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: fogflow                      
+  name: rabbitmq
+  labels:
+    run: rabbitmq
+spec:
+  type: LoadBalancer
+  ports:  
+    - name: "5672"
+      port: 5672
+      targetPort: 5672
+  selector:
+    run: rabbitmq
+
+
+

--- a/deployment/kubernetes/cloud-node/retag-image.sh
+++ b/deployment/kubernetes/cloud-node/retag-image.sh
@@ -1,0 +1,5 @@
+docker image tag fogflow/designer:latest  fogflow/designer:k8s 
+docker image tag fogflow/discovery:latest  fogflow/discovery:k8s 
+docker image tag fogflow/broker:latest  fogflow/broker:k8s 
+docker image tag fogflow/master:latest  fogflow/master:k8s 
+docker image tag fogflow/worker:latest  fogflow/worker:k8s 

--- a/deployment/kubernetes/cloud-node/uninstall.sh
+++ b/deployment/kubernetes/cloud-node/uninstall.sh
@@ -1,0 +1,16 @@
+kubectl delete -f nginx.yaml
+
+kubectl delete -f configmap.yaml
+
+kubectl delete -f discovery.yaml
+kubectl delete -f broker.yaml
+kubectl delete -f dgraph.yaml
+kubectl delete -f rabbitmq.yaml
+kubectl delete -f master.yaml
+kubectl delete -f worker.yaml
+kubectl delete -f designer.yaml
+
+
+kubectl delete namespace fogflow
+
+

--- a/deployment/kubernetes/cloud-node/worker.yaml
+++ b/deployment/kubernetes/cloud-node/worker.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: fogflow                      
+  name: cloudworker
+spec:
+  selector:
+    matchLabels:
+      run: cloudworker
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: cloudworker
+    spec:
+      containers:
+      - name: cloudworker
+        image: fogflow/worker:k8s
+        volumeMounts:
+        - name: config-json       
+          mountPath: /config.json
+          subPath: config.json                
+          readOnly: true
+        - name: dockersock
+          mountPath: "/var/run/docker.sock"  
+        - name: tmp-folder
+          mountPath: /tmp
+          readOnly: true                    
+      volumes:
+      - name: config-json 
+        configMap:
+          name: fogflow-configmap     
+      - name: tmp-folder
+        hostPath:
+          path: /tmp
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+             
+          
+
+

--- a/docker/core/http/local/config.json
+++ b/docker/core/http/local/config.json
@@ -1,7 +1,5 @@
 {
-    "coreservice_ip": "192.168.0.59",
-    "external_ip": "192.168.0.59",
-    "my_hostip": "192.168.0.59",
+    "my_hostip": "host.docker.internal",
     "physical_location":{
         "longitude": 139,
         "latitude": 35

--- a/k8sWorker/executor.go
+++ b/k8sWorker/executor.go
@@ -262,7 +262,10 @@ func (e *Executor) LaunchTask(task *ScheduledTaskInstance) bool {
 	// pass the reference URL to the task so that the task can issue context subscription as well
 	setReferenceCmd := make(map[string]interface{})
 	setReferenceCmd["command"] = "SET_REFERENCE"
-	setReferenceCmd["url"] = "http://" + e.workerCfg.InternalIP + ":" + freePort
+
+	//setReferenceCmd["url"] = "http://" + e.workerCfg.InternalIP + ":" + freePort
+	setReferenceCmd["url"] = "http://fogflow-deployment-" + freePort + ":" + freePort
+
 	commands = append(commands, setReferenceCmd)
 
 	// set output stream
@@ -305,6 +308,7 @@ func (e *Executor) LaunchTask(task *ScheduledTaskInstance) bool {
 		ERROR.Println(err)
 		return false
 	}*/
+
 	//INFO.Printf(" task %s  started within container = %s\n", task.ID, containerId)
 	INFO.Printf(" task %s  started within container = %s\n", task.ID, podId)
 

--- a/k8sWorker/pod.go
+++ b/k8sWorker/pod.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
+
 	docker "github.com/fsouza/go-dockerclient"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -20,26 +21,8 @@ type pod struct {
 }
 
 func (p *pod) pod(dockerImage string, port string, adminCfg []interface{}) (string, error) {
+	jsonString, _ := json.Marshal(adminCfg)
 
-	var brokerURL, url, id, Etype string
-	for _, commandValue := range adminCfg {
-		commandValueMap := commandValue.(map[string]interface{})
-		for key, value := range commandValueMap {
-			fmt.Println("key", key)
-			if key == "brokerURL" {
-				brokerURL = value.(string)
-			}
-			if key == "url" {
-				url = value.(string)
-			}
-			if key == "id" {
-				id = value.(string)
-			}
-			if key == "type" {
-				Etype = value.(string)
-			}
-		}
-	}
 	// creates the in-cluster config
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -56,11 +39,11 @@ func (p *pod) pod(dockerImage string, port string, adminCfg []interface{}) (stri
 		panic(err.Error())
 	}
 
-	deploymentsClient := clientset.AppsV1().Deployments(apiv1.NamespaceDefault)
+	deploymentsClient := clientset.AppsV1().Deployments("fogflow")
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "fogflow-deployment" + port,
+			Name: "fogflow-deployment-" + port,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -93,20 +76,8 @@ func (p *pod) pod(dockerImage string, port string, adminCfg []interface{}) (stri
 									Value: port,
 								},
 								{
-									Name:  "brokerURL",
-									Value: brokerURL,
-								},
-								{
-									Name:  "url",
-									Value: url,
-								},
-								{
-									Name:  "id",
-									Value: id,
-								},
-								{
-									Name:  "type",
-									Value: Etype,
+									Name:  "adminCfg",
+									Value: string(jsonString),
 								},
 							},
 						},
@@ -126,26 +97,22 @@ func (p *pod) pod(dockerImage string, port string, adminCfg []interface{}) (stri
 
 	serviceSpec := &coreV1.Service{
 		ObjectMeta: metaV1.ObjectMeta{
-			Name: "fogflow-deployment" + port,
+			Namespace: "fogflow",
+			Name:      "fogflow-deployment-" + port,
 		},
 		Spec: coreV1.ServiceSpec{
 			Selector: map[string]string{
 				"app": "demo",
 			},
-			Type: "LoadBalancer",
 			Ports: []coreV1.ServicePort{
 				{
 					Port: pport,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: pport,
-					},
 				},
 			},
 		},
 	}
 
-	service, err := coreV1Client.Services(apiv1.NamespaceDefault).Create(context.TODO(), serviceSpec, metaV1.CreateOptions{})
+	service, err := coreV1Client.Services("fogflow").Create(context.TODO(), serviceSpec, metaV1.CreateOptions{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- fix the master to add the mechanism to wait and reconnect to the discovery and broker at the bootstrap phase
- change the designer to reconnect to the dgraph when dgraph server is not ready
- change the configuration file to allow FogFlow components to use clusterIP for their internal communication in the k8s cluster
- add the new scripts to start fogflow in k8s and also use configmap for mounting the config.json file